### PR TITLE
Support mongodb/mongodb 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "ext-mongodb": "*",
-        "mongodb/mongodb": "^1.8",
+        "mongodb/mongodb": "^1.8 || ^2.0",
         "symfony/console": "^2.7 || ^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/yaml": "^2.7 || ^3.4 || ^4.0 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0",
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.5",
         "friendsofphp/php-cs-fixer": "^2.0",
         "mikey179/vfsstream": "1.*"
     },

--- a/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
+++ b/src/AntiMattr/MongoDB/Migrations/Collection/Statistics.php
@@ -122,8 +122,9 @@ class Statistics
     protected function getCollectionStats()
     {
         $name = $this->collection->getCollectionName();
-
-        if (!$data = $this->database->command(['collStats' => $name])) {
+	    $result = $this->database->command(['collStats' => $name]);
+	    $data = $result->toArray();
+	    if (empty($data)) {
             $message = sprintf(
                 'Statistics not found for collection %s',
                 $name

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -311,8 +311,9 @@ class Configuration
         $this->createMigrationCollection();
 
         $cursor = $this->getCollection()->find();
+		$array = $cursor->toArray();
         $versions = [];
-        foreach ($cursor as $record) {
+        foreach ($array as $record) {
             $versions[] = $record['v'];
         }
 

--- a/src/AntiMattr/MongoDB/Migrations/Version.php
+++ b/src/AntiMattr/MongoDB/Migrations/Version.php
@@ -245,13 +245,13 @@ class Version
      * @param \MongoDB\Database
      * @param string $file
      *
-     * @return array
+     * @return \MongoDB\Driver\Cursor
      *
      * @throws RuntimeException
      * @throws InvalidArgumentException
      * @throws Exception
      */
-    public function executeScript(Database $db, $file)
+    public function executeScript(Database $db, $file): \MongoDB\Driver\Cursor
     {
         $scripts = $this->configuration->getMigrationsScriptDirectory();
         if (null === $scripts) {

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Collection/StatisticsTest.php
@@ -3,6 +3,8 @@
 namespace AntiMattr\Tests\MongoDB\Migrations\Collection;
 
 use AntiMattr\MongoDB\Migrations\Collection\Statistics;
+use Exception;
+use MongoDB\Driver\CursorInterface;
 use PHPUnit\Framework\TestCase;
 
 class StatisticsTest extends TestCase
@@ -22,12 +24,10 @@ class StatisticsTest extends TestCase
         $this->assertEquals($this->collection, $this->statistics->getCollection());
     }
 
-    /**
-     * @expectedException \Exception
-     */
-    public function testGetCollectionStatsThrowsExceptionWhenDataNotFound()
+	public function testGetCollectionStatsThrowsExceptionWhenDataNotFound()
     {
-        $database = $this->createMock('MongoDB\Database');
+	    $this->expectException(Exception::class);
+	    $database = $this->createMock('MongoDB\Database');
 
         $this->statistics = new StatisticsStub();
         $this->statistics->setCollection($this->collection);
@@ -56,9 +56,15 @@ class StatisticsTest extends TestCase
             'count' => 100,
         ];
 
+	    $cursor = $this->createMock(CursorInterface::class);
+
+	    $cursor->expects($this->once())
+		    ->method('toArray')
+		    ->willReturn($expectedData);
+
         $database->expects($this->once())
             ->method('command')
-            ->will($this->returnValue($expectedData));
+            ->willReturn($cursor);
 
         $data = $this->statistics->doGetCollectionStats();
 

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/TimestampTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Configuration/TimestampTest.php
@@ -3,6 +3,7 @@
 namespace AntiMattr\Tests\MongoDB\Migrations\Configuration;
 
 use AntiMattr\MongoDB\Migrations\Configuration\Timestamp;
+use DomainException;
 use PHPUnit\Framework\TestCase;
 
 class TimestampTest extends TestCase
@@ -56,19 +57,15 @@ class TimestampTest extends TestCase
         return $timestamps;
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testWillThrowAnExceptionForUnknownClass()
+	public function testWillThrowAnExceptionForUnknownClass()
     {
-        (new Timestamp(new \stdClass()))->getTimestamp();
+	    $this->expectException(DomainException::class);
+	    (new Timestamp(new \stdClass()))->getTimestamp();
     }
 
-    /**
-     * @expectedException \DomainException
-     */
-    public function testWillThrowAnExceptionForNull()
+	public function testWillThrowAnExceptionForNull()
     {
-        (new Timestamp(null))->getTimestamp();
+	    $this->expectException(DomainException::class);
+	    (new Timestamp(null))->getTimestamp();
     }
 }

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/MigrationTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/MigrationTest.php
@@ -2,6 +2,8 @@
 
 namespace AntiMattr\Tests\MongoDB\Migrations;
 
+use AntiMattr\MongoDB\Migrations\Exception\NoMigrationsToExecuteException;
+use AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException;
 use AntiMattr\MongoDB\Migrations\Migration;
 use PHPUnit\Framework\TestCase;
 
@@ -23,12 +25,10 @@ class MigrationTest extends TestCase
         $this->migration = new Migration($this->configuration);
     }
 
-    /**
-     * @expectedException \AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException
-     */
-    public function testMigrateThrowsUnknownVersionException()
+	public function testMigrateThrowsUnknownVersionException()
     {
-        $this->migration->migrate('1');
+	    $this->expectException(UnknownVersionException::class);
+	    $this->migration->migrate('1');
     }
 
     public function testMigrateHasNothingOutstanding()
@@ -51,12 +51,10 @@ class MigrationTest extends TestCase
         $this->migration->migrate('1');
     }
 
-    /**
-     * @expectedException \AntiMattr\MongoDB\Migrations\Exception\NoMigrationsToExecuteException
-     */
-    public function testMigrateButNoMigrationsFound()
+	public function testMigrateButNoMigrationsFound()
     {
-        $this->configuration->expects($this->once())
+	    $this->expectException(NoMigrationsToExecuteException::class);
+	    $this->configuration->expects($this->once())
             ->method('getCurrentVersion')
             ->will($this->returnValue('1'));
 

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/GenerateCommandTest.php
@@ -3,8 +3,11 @@
 namespace AntiMattr\Tests\MongoDB\Migrations\Tools\Console\Command;
 
 use AntiMattr\MongoDB\Migrations\Tools\Console\Command\GenerateCommand;
+use InvalidArgumentException;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArgvInput;
 
 /**
@@ -60,6 +63,8 @@ class GenerateCommandTest extends TestCase
                 $this->returnValue(vfsStream::url($migrationsDirectory))
             )
         ;
+	    $application = new Application();
+	    $this->command->setApplication($application);
 
         $this->command->run(
             $input,
@@ -75,12 +80,10 @@ class GenerateCommandTest extends TestCase
         $this->assertTrue($root->hasChild($filename));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExecuteWithInvalidMigrationDirectory()
+	public function testExecuteWithInvalidMigrationDirectory()
     {
-        $migrationsNamespace = 'migrations-namespace';
+	    $this->expectException(InvalidArgumentException::class);
+	    $migrationsNamespace = 'migrations-namespace';
         $migrationsDirectory = 'missing-directory';
 
         $root = vfsStream::setup('Base');
@@ -109,6 +112,16 @@ class GenerateCommandTest extends TestCase
                 )
             )
         ;
+
+		$question = $this->createMock('Symfony\Component\Console\Helper\QuestionHelper');
+		$application = new Application();
+	    $helperSet = new HelperSet(
+		    [
+			    'question' => $question,
+		    ]
+	    );
+	    $application->setHelperSet($helperSet);
+	    $this->command->setApplication($application);
 
         // Run command, run.
         $this->command->run(

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/MigrateCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/MigrateCommandTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -101,12 +102,10 @@ class MigrateCommandTest extends TestCase
 
         // Variables and Objects
         $numVersion = '000123456789';
-        $input = new ArgvInput(
-            [
-                MigrateCommand::getDefaultName(),
-                $numVersion,
-            ]
-        );
+	    $input = new ArrayInput([
+		    'command' => MigrateCommand::getDefaultName(),
+		    'version' => $numVersion,
+	    ]);
         $interactive = false;
         $availableVersions = [$availableVersion];
 
@@ -134,6 +133,10 @@ class MigrateCommandTest extends TestCase
             ->method('migrate')
             ->with($numVersion)
         ;
+
+	    $application = new Application();
+
+	    $this->command->setApplication($application);
 
         // Run command, run.
         $this->command->run(

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/VersionCommandTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/Tools/Console/Command/VersionCommandTest.php
@@ -3,10 +3,15 @@
 namespace AntiMattr\Tests\MongoDB\Migrations\Tools\Console\Command;
 
 use AntiMattr\MongoDB\Migrations\Configuration\Configuration;
+use AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException;
 use AntiMattr\MongoDB\Migrations\Migration;
+use AntiMattr\MongoDB\Migrations\Tools\Console\Command\MigrateCommand;
 use AntiMattr\MongoDB\Migrations\Tools\Console\Command\VersionCommand;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * @author Ryan Catlin <ryan.catlin@gmail.com>
@@ -29,21 +34,27 @@ class VersionCommandTest extends TestCase
 
         $this->command->setMigrationConfiguration($this->config);
         $this->command->setMigration($this->migration);
+
+	    $question = $this->createMock('Symfony\Component\Console\Helper\QuestionHelper');
+	    $application = new Application();
+	    $helperSet = new HelperSet(
+		    [
+			    'question' => $question,
+		    ]
+	    );
+	    $application->setHelperSet($helperSet);
+	    $this->command->setApplication($application);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidArgumentException()
+	public function testInvalidArgumentException()
     {
-        // Variables and objects
+	    $this->expectException(InvalidArgumentException::class);
+	    // Variables and objects
         $numVersion = '123456789012';
-        $input = new ArgvInput(
-            [
-                VersionCommand::getDefaultName(),
-                $numVersion,
-            ]
-        );
+	    $input = new ArrayInput([
+		    'command' => MigrateCommand::getDefaultName(),
+		    'version' => $numVersion,
+	    ]);
 
         // Run command, run.
         $this->command->run(
@@ -52,27 +63,30 @@ class VersionCommandTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException
-     */
-    public function testUnknownVersionException()
+	public function testUnknownVersionException()
     {
-        // Variables and objects
-        $numVersion = '123456789012';
-        $input = new ArgvInput(
-            [
-                VersionCommand::getDefaultName(),
-                $numVersion,
-                '--add',
-            ]
-        );
+	    $this->expectException(UnknownVersionException::class);
+	    // Variables and objects
+	    // Variables and objects
+	    $numVersion = '123456789012';
+	    $input = new ArrayInput([
+		    'command' => MigrateCommand::getDefaultName(),
+		    'version' => $numVersion,
+		    '--add' => true
+	    ]);
+
+	    // Run command, run.
+	    $this->command->run(
+		    $input,
+		    $this->output
+	    );
 
         // Expectations
         $this->config->expects($this->once())
             ->method('hasVersion')
             ->with($numVersion)
-            ->will(
-                $this->returnValue(false)
+            ->willReturn(
+	            false
             )
         ;
 
@@ -87,13 +101,11 @@ class VersionCommandTest extends TestCase
     {
         // Variables and objects
         $numVersion = '123456789012';
-        $input = new ArgvInput(
-            [
-                VersionCommand::getDefaultName(),
-                $numVersion,
-                '--add',
-            ]
-        );
+	    $input = new ArrayInput([
+		    'command' => VersionCommand::getDefaultName(),
+		    'version' => $numVersion,
+		    '--add' => true,
+	    ]);
 
         // Expectations
         $this->config->expects($this->once())
@@ -135,13 +147,11 @@ class VersionCommandTest extends TestCase
     {
         // Variables and objects
         $numVersion = '123456789012';
-        $input = new ArgvInput(
-            [
-                VersionCommand::getDefaultName(),
-                $numVersion,
-                '--delete',
-            ]
-        );
+	    $input = new ArrayInput([
+		    'command' => VersionCommand::getDefaultName(),
+		    'version' => $numVersion,
+		    '--delete' => true,
+	    ]);
 
         // Expectations
         $this->config->expects($this->once())
@@ -179,20 +189,16 @@ class VersionCommandTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testDownOnNonMigratedVersionThrowsInvalidArgumentException()
+	public function testDownOnNonMigratedVersionThrowsInvalidArgumentException()
     {
-        // Variables and objects
+	    $this->expectException(InvalidArgumentException::class);
+	    // Variables and objects
         $numVersion = '123456789012';
-        $input = new ArgvInput(
-            [
-                VersionCommand::getDefaultName(),
-                $numVersion,
-                '--delete',
-            ]
-        );
+	    $input = new ArrayInput([
+		    'command' => VersionCommand::getDefaultName(),
+		    'version' => $numVersion,
+		    '--delete' => true,
+	    ]);
 
         // Expectations
         $this->config->expects($this->once())
@@ -226,20 +232,16 @@ class VersionCommandTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testUpOnMigratedVersionThrowsInvalidArgumentException()
+	public function testUpOnMigratedVersionThrowsInvalidArgumentException()
     {
-        // Variables and objects
+	    $this->expectException(InvalidArgumentException::class);
+	    // Variables and objects
         $numVersion = '123456789012';
-        $input = new ArgvInput(
-            [
-                VersionCommand::getDefaultName(),
-                $numVersion,
-                '--add',
-            ]
-        );
+	    $input = new ArrayInput([
+		    'command' => VersionCommand::getDefaultName(),
+		    'version' => $numVersion,
+		    '--add' => true,
+	    ]);
 
         // Expectations
         $this->config->expects($this->once())

--- a/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
+++ b/tests/AntiMattr/Tests/MongoDB/Migrations/VersionTest.php
@@ -3,6 +3,7 @@
 namespace AntiMattr\Tests\MongoDB\Migrations;
 
 use AntiMattr\MongoDB\Migrations\AbstractMigration;
+use AntiMattr\MongoDB\Migrations\Exception\AbortException;
 use AntiMattr\MongoDB\Migrations\Version;
 use MongoDB\BSON\UTCDateTime;
 use MongoDB\Database;
@@ -231,11 +232,12 @@ class VersionTest extends TestCase
      *
      * testExecuteDownWithReplayThrowsException
      *
-     * @expectedException \AntiMattr\MongoDB\Migrations\Exception\AbortException
+     *
      */
     public function testExecuteDownWithReplayThrowsException()
     {
-        // These methods will not be called
+	    $this->expectException(AbortException::class);
+	    // These methods will not be called
         $this->migration->expects($this->never())->method('down');
         $this->configuration->expects($this->never())
             ->method('createMigrationCollection');


### PR DESCRIPTION
Hi @spantaleev,

Those are minimal changes I have done in order to make the code work with PHP 8.4.6 and https://pecl.php.net/package/mongodb/2.0.0.

This should eventually allow https://github.com/devture/mongodb-migrations-bundle to work with  PHP extension mongodb 2.0.0.

Code is by far not perfect but it does the work for now. If you want I can help on my spare time to clean up the code as it seem quite old now.