### PR TITLE
avoid implicit nullable variable

### DIFF
--- a/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
+++ b/src/AntiMattr/MongoDB/Migrations/AbstractMigration.php
@@ -81,11 +81,11 @@ abstract class AbstractMigration
     }
 
     /**
-     * @param string $message
+     * @param string|null $message
      *
      * @throws AntiMattr\MongoDB\Migrations\Exception\IrreversibleException
      */
-    protected function throwIrreversibleMigrationException($message = null)
+    protected function throwIrreversibleMigrationException(?string $message = null)
     {
         if (null === $message) {
             $message = 'This migration is irreversible and cannot be reverted.';

--- a/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Configuration/Configuration.php
@@ -105,7 +105,7 @@ class Configuration
     /**
      * @param \AntiMattr\MongoDB\Migrations\OutputWriter $outputWriter
      */
-    public function __construct(Client $connection, OutputWriter $outputWriter = null)
+    public function __construct(Client $connection, ?OutputWriter $outputWriter = null)
     {
         $this->connection = $connection;
         if (null === $outputWriter) {

--- a/src/AntiMattr/MongoDB/Migrations/Migration.php
+++ b/src/AntiMattr/MongoDB/Migrations/Migration.php
@@ -46,12 +46,12 @@ class Migration
     /**
      * Run a migration to the current version or the given target version.
      *
-     * @param string $to The version to migrate to
+     * @param string|null $to The version to migrate to
      *
      * @throws AntiMattr\MongoDB\Migrations\Exception\UnknownVersionException
      * @throws AntiMattr\MongoDB\Migrations\Exception\NoMigrationsToExecuteException
      */
-    public function migrate($to = null)
+    public function migrate(?string $to = null)
     {
         if (null === $to) {
             $to = $this->configuration->getLatestVersion();

--- a/src/AntiMattr/MongoDB/Migrations/OutputWriter.php
+++ b/src/AntiMattr/MongoDB/Migrations/OutputWriter.php
@@ -11,6 +11,8 @@
 
 namespace AntiMattr\MongoDB\Migrations;
 
+use Closure;
+
 /**
  * @author Matthew Fitzgerald <matthewfitz@gmail.com>
  */
@@ -18,7 +20,7 @@ class OutputWriter
 {
     private $closure;
 
-    public function __construct(\Closure $closure = null)
+    public function __construct(?Closure $closure = null)
     {
         if (null === $closure) {
             $closure = function ($message) {
@@ -30,7 +32,7 @@ class OutputWriter
     /**
      * @param string $message The message to write
      */
-    public function write($message)
+    public function write(string $message)
     {
         $closure = $this->closure;
         $closure($message);

--- a/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/src/AntiMattr/MongoDB/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -96,15 +96,15 @@ EOT
     /**
      * @param \AntiMattr\MongoDB\Migrations\Configuration\Configuration
      * @param \Symfony\Component\Console\Input\InputInterface
-     * @param string $version
-     * @param string $up
-     * @param string $down
+     * @param string      $version
+     * @param string|null $up
+     * @param string|null $down
      *
      * @return string $path
      *
      * @throws \InvalidArgumentException
      */
-    protected function generateMigration(Configuration $configuration, InputInterface $input, $version, $up = null, $down = null)
+    protected function generateMigration(Configuration $configuration, InputInterface $input, string $version, ?string $up = null,  ?string $down = null)
     {
         $placeHolders = [
             '<namespace>',


### PR DESCRIPTION
Hi @spantaleev,

I noticed that there is some deprecation on the code when working with latest PHP 8.4.6. (Basically this one: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)

So I updated the code to avoid those exceptions